### PR TITLE
Bugfix for helm values and destinationrule

### DIFF
--- a/helm/environments/dev-env.yaml
+++ b/helm/environments/dev-env.yaml
@@ -10,7 +10,7 @@ deployments:
     image:
       repository: mzraacrind01.azurecr.io/nodejs-colorizedapp
       pullPolicy: Always
-      tag: "bugfix_issues-with-helm-values-0b2d1b4"
+      tag: "1.1.6"
 
     env:
       MESSAGE: "Hello from dev-env d1"

--- a/helm/environments/dev-env.yaml
+++ b/helm/environments/dev-env.yaml
@@ -10,7 +10,7 @@ deployments:
     image:
       repository: mzraacrind01.azurecr.io/nodejs-colorizedapp
       pullPolicy: Always
-      tag: "1.1.6"
+      tag: "bugfix_issues-with-helm-values-0b2d1b4"
 
     env:
       MESSAGE: "Hello from dev-env d1"

--- a/helm/nodejs-colorizedapp/templates/destinationrule.yaml
+++ b/helm/nodejs-colorizedapp/templates/destinationrule.yaml
@@ -10,10 +10,8 @@ spec:
     - name: d1
       labels:
         {{- include "nodejs-colorizedapp.labels" . | nindent 8 }}
-        {{- include "nodejs-colorizedapp.versionLabel" (list . .Values.deployments.d1.image.tag) | nindent 8 }}
         {{- include "nodejs-colorizedapp.selectorLabels" (list . "d1") | nindent 8 }}
     - name: d2
       labels:
         {{- include "nodejs-colorizedapp.labels" . | nindent 8 }}
-        {{- include "nodejs-colorizedapp.versionLabel" (list . .Values.deployments.d2.image.tag) | nindent 8 }}
         {{- include "nodejs-colorizedapp.selectorLabels" (list . "d2") | nindent 8 }}

--- a/infra/kubernetes/argocd/README.md
+++ b/infra/kubernetes/argocd/README.md
@@ -35,10 +35,13 @@ source:
   targetRevision: master
   helm:
     valueFiles:
+      - ../nodejs-colorizedapp/values.yaml
+      - ../environments/common.yaml
       - ../environments/dev-env.yaml
 destination:
   server: 'https://kubernetes.default.svc'
   namespace: dev-env
 syncPolicy:
   automated: {}
+
 ```


### PR DESCRIPTION
Changes:
* fix issues with missing values.yaml file in ArgoCD: because of missing values.yaml, healthchecks were not applied to pods
* fix issues with invalid destinantionrule: label with version caused that traffic was directed only to particular pod even if rollout was failed. By removing this label connections are forwarded to both: healthy and unhalthy pod causing no downtime